### PR TITLE
Rewrite jQuery-dependent parts of the code

### DIFF
--- a/src/tree-repeat.js
+++ b/src/tree-repeat.js
@@ -71,24 +71,24 @@
     return {
       // which must come from a parent `sf-treepeat`.
       require: "^sfTreepeat",
-      link: function sfTreecursePostLink(scope, iterStartElement, attrs, controller) {
+      link: function sfTreecursePostLink(scope, iterStartElementJqLiteOrJquery, attrs, controller) {
         // Now we stitch together an element containing a vanila repeater using
         // the values from the controller.
+        var iterStartElementDOM = iterStartElementJqLiteOrJquery[0];
         var build = [
-          '<', iterStartElement.context.tagName, ' ng-repeat="',
+          '<', iterStartElementDOM.tagName, ' ng-repeat="',
           controller.ident.value, ' in ',
           controller.ident.value, '.', controller.ident.collection,
           '">',
           controller.template,
-          '</', iterStartElement.context.tagName, '>'];
+          '</', iterStartElementDOM.tagName, '>'];
         var el = angular.element(build.join(''));
         // We swap out the element for our new one and tell angular to do its
         // thing with that.
-        iterStartElement.replaceWith(el);
+        iterStartElementJqLiteOrJquery.replaceWith(el);
         $compile(el)(scope);
       }
     };
   }]);
 
 }());
-


### PR DESCRIPTION
The sfTreecurse directive's link function referred to the context property of the element, which it doesn't have if jQuery is not loaded, so the module was broken in this case. (By default, Angular wraps elements in jqLite, but if jQuery is loaded, it wraps them in jQuery. So if the module was only tested with jQuery loaded, you couldn't notice this issue.) A possible solution would be to explicitly add jQuery as a dependency, but since this was the only part of the code that depended on jQuery, I rather rewrote this part, and also tested that the module still works if jQuery is loaded.